### PR TITLE
fix: yarn create時に`minimist`が見つからないエラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
     "lint:fix": "prettier --write src/**/*.ts",
     "prepublishOnly": "npm run build"
   },
+  "dependencies": {
+    "minimist": "^1.2.8",
+    "kolorist": "^1.8.0",
+    "prompts": "^2.4.2"
+  },
   "devDependencies": {
     "@types/lodash-es": "^4.17.7",
     "@types/minimist": "^1.2.2",
@@ -37,11 +42,8 @@
     "@typescript-eslint/parser": "^5.61.0",
     "esbuild": "^0.18.11",
     "eslint": "^8.44.0",
-    "kolorist": "^1.8.0",
     "lodash-es": "^4.17.21",
-    "minimist": "^1.2.8",
     "prettier": "^3.0.0",
-    "prompts": "^2.4.2",
     "typescript": "^5.1.6"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,7 +8,7 @@ async function bundle() {
     format: "cjs",
     platform: "node",
     target: "node16",
-    external: ["minimist", "prompts"],
+    external: ["minimist", "prompts", "kolorist"],
   });
 }
 


### PR DESCRIPTION
- minimist, kolorist, promptsを`dependency`ブロックへ移動
- build scriptのexternalに`kolorist`を追加